### PR TITLE
GUNDI-4065: Enhancements

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -64,7 +64,7 @@ async def get_observations(integration, base_url, config):
 
         params = {
             "collarkey": config.collar_key,
-            "afterScts": config.start.isoformat().split("+")[0]
+            "afterScts": config.start.strftime("%Y-%m-%dT%H:%M:%S")
         }
 
         try:

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -12,7 +12,13 @@ class PullObservationsConfig(PullActionConfiguration):
         title="JSON String of Collars",
         description="A JSON string representing a list of collars to be processed",
     )
-    default_lookback_hours: int = 12
+    default_lookback_hours: int = FieldWithUIOptions(
+        title="Data Retrieval Period (Hours)",
+        description="Number of hours to look back for observations (Max 168 hours = 7 days)",
+        default=12,
+        ge=1,
+        le=168,  # Limit to max 7 days
+    )
 
 
 class PullCollarObservationsConfig(InternalActionConfiguration):

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -7,6 +7,9 @@ from app.services.errors import ConfigurationNotFound
 from app.services.utils import find_config_for_action, FieldWithUIOptions
 
 
+MAX_LOOKBACK_HOURS = 168  # 7 days
+
+
 class PullObservationsConfig(PullActionConfiguration):
     files: str = FieldWithUIOptions(
         title="JSON String of Collars",
@@ -17,7 +20,7 @@ class PullObservationsConfig(PullActionConfiguration):
         description="Number of hours to look back for observations (Max 168 hours = 7 days)",
         default=12,
         ge=1,
-        le=168,  # Limit to max 7 days
+        le=MAX_LOOKBACK_HOURS
     )
 
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -82,10 +82,10 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             )
             if not device_state:
                 logger.info(f"Setting initial lookback hours for device {parsed_collar.collar_id} to {action_config.default_lookback_hours}")
-                start = (now - timedelta(hours=action_config.default_lookback_hours)).strftime("%Y-%m-%dT%H:%M:%S")
+                start = now - timedelta(hours=action_config.default_lookback_hours)
             else:
                 logger.info(f"Setting begin time for device {parsed_collar.collar_id} to {device_state.get('updated_at')}")
-                start = device_state.get("updated_at")
+                start = datetime.fromisoformat(device_state.get("updated_at")).replace(tzinfo=timezone.utc)
 
             parsed_config = PullCollarObservationsConfig(
                 start=start,


### PR DESCRIPTION
This pull request makes improvements to how observation retrieval periods are configured and handled, providing better validation and consistency in date handling. 

The main changes include updating configuration options to enforce limits, improving date formatting, and ensuring consistent datetime handling throughout the code.

**Configuration Enhancements:**

* [`app/actions/configurations.py`](diffhunk://#diff-0c07ea434f0a65b6e42dfb436000af783a7bd80e905bbed3d9cb7f67b779d895L15-R21): The `default_lookback_hours` field in `PullObservationsConfig` now uses `FieldWithUIOptions` to provide a user-friendly title and description, and enforces a range between 1 and 168 hours (1 to 7 days).

**Datetime Handling Improvements:**

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L85-R88): In `action_pull_observations`, the calculation and assignment of the `start` time for observation retrieval now consistently uses `datetime` objects, ensuring proper timezone handling and avoiding premature string formatting.
* [`app/actions/client.py`](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L67-R67): The `get_observations` function now formats the `afterScts` parameter using `strftime("%Y-%m-%dT%H:%M:%S")` for consistency and to avoid issues with timezone offsets.