### PR TITLE
GUNDI-5420: Downgrade unauthorized collar access log from ERROR to WARNING

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -155,7 +155,7 @@ async def action_fetch_collar_observations(integration, action_config: PullColla
         await log_action_activity(
             integration_id=integration.id,
             action_id="pull_observations",
-            level=LogLevel.ERROR,
+            level=LogLevel.WARNING,
             title="Unauthorized access (bad collar key and/or collar ID)",
             data={"message": message, "data": action_config}
         )

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -166,7 +166,7 @@ async def action_fetch_collar_observations(integration, action_config: PullColla
         await log_action_activity(
             integration_id=integration.id,
             action_id="pull_observations",
-            level=LogLevel.ERROR,
+            level=LogLevel.WARNING,
             title=f"Collar ID {action_config.collar_id} not found.",
             data={"message": message, "data": action_config}
         )


### PR DESCRIPTION
## Summary

- Downgrades log level from `ERROR` to `WARNING` for two per-source failure cases in the Vectronic connector:
  - "Unauthorized access (bad collar key and/or collar ID)"
  - "Collar ID not found"
- Inactive or misconfigured sources should not make a healthy connection appear unhealthy when other sources are pulling data successfully

Jira: [GUNDI-5420](https://allenai.atlassian.net/browse/GUNDI-5420)

## Test plan

- [ ] Verify that a collar with a bad key/ID logs a warning (not an error) in the activity log
- [ ] Verify that a collar with an unknown ID logs a warning (not an error) in the activity log
- [ ] Verify that the connection health status is not degraded when other collars in the same connection are pulling data successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GUNDI-5420]: https://allenai.atlassian.net/browse/GUNDI-5420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ