### PR TITLE
Log collar-fetch 4xx/5xx responses as WARNING, not ERROR

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import httpx
 import pydantic
 
 import app.actions.client as client
@@ -151,23 +152,37 @@ async def action_fetch_collar_observations(integration, action_config: PullColla
             return {"observations_extracted": 0}
     except client.VectronicForbiddenException as e:
         message = f"Unauthorized response from Vectronic with integration {integration.id} using {action_config}. Exception: {e}"
-        logger.exception(message)
+        logger.warning(message)
         await log_action_activity(
             integration_id=integration.id,
-            action_id="pull_observations",
-            level=LogLevel.ERROR,
+            action_id="fetch_collar_observations",
+            level=LogLevel.WARNING,
             title="Unauthorized access (bad collar key and/or collar ID)",
             data={"message": message, "data": action_config}
         )
         return {"observations_extracted": 0}
     except client.VectronicNotFoundException as e:
         message = f"Collar ID {action_config.collar_id} not found. Integration {integration.id} using {action_config}. Exception: {e}"
-        logger.exception(message)
+        logger.warning(message)
         await log_action_activity(
             integration_id=integration.id,
-            action_id="pull_observations",
-            level=LogLevel.ERROR,
+            action_id="fetch_collar_observations",
+            level=LogLevel.WARNING,
             title=f"Collar ID {action_config.collar_id} not found.",
+            data={"message": message, "data": action_config}
+        )
+        return {"observations_extracted": 0}
+    except httpx.HTTPStatusError as e:
+        # Other 4xx/5xx responses from the collar API (403/404 are handled above).
+        # These are upstream/transient conditions, not integration errors, so log as a warning.
+        status_code = e.response.status_code
+        message = f"Vectronic returned HTTP {status_code} for collar {action_config.collar_id} from integration ID {integration.id}. Exception: {e}"
+        logger.warning(message)
+        await log_action_activity(
+            integration_id=integration.id,
+            action_id="fetch_collar_observations",
+            level=LogLevel.WARNING,
+            title=f"Vectronic returned HTTP {status_code} for collar {action_config.collar_id}.",
             data={"message": message, "data": action_config}
         )
         return {"observations_extracted": 0}
@@ -176,7 +191,7 @@ async def action_fetch_collar_observations(integration, action_config: PullColla
         logger.exception(message)
         await log_action_activity(
             integration_id=integration.id,
-            action_id="pull_observations",
+            action_id="fetch_collar_observations",
             level=LogLevel.ERROR,
             title=f"Failed to fetch observations for collar {action_config.collar_id}.",
             data={"message": message, "data": action_config}

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,10 +1,15 @@
 import pytest
 import json
+import httpx
 from app import settings
 from pydantic import ValidationError
 from gundi_core.schemas.v2 import LogLevel
 from unittest.mock import AsyncMock, MagicMock
-from app.actions.client import VectronicObservation
+from app.actions.client import (
+    VectronicObservation,
+    VectronicForbiddenException,
+    VectronicNotFoundException,
+)
 from app.actions.handlers import (
     action_pull_observations,
     action_fetch_collar_observations,
@@ -118,8 +123,53 @@ async def test_action_fetch_collar_observations_exception_sends_error_activity_l
     assert result == {"observations_extracted": 0}
     mock_log_action_activity.assert_awaited_once()
     assert mock_log_action_activity.call_args[1]["integration_id"] == integration.id
+    assert mock_log_action_activity.call_args[1]["action_id"] == "fetch_collar_observations"
     assert mock_log_action_activity.call_args[1]["level"] == LogLevel.ERROR
     assert mock_log_action_activity.call_args[1]["title"] == f"Failed to fetch observations for collar {config.collar_id}."
+
+@pytest.mark.asyncio
+async def test_action_fetch_collar_observations_forbidden_logs_warning(mocker):
+    mock_get_obs = mocker.patch("app.actions.handlers.client.get_observations", new_callable=AsyncMock)
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new_callable=AsyncMock)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    integration = MagicMock(id=1, base_url=None)
+    config = PullCollarObservationsConfig(start="2024-01-01T00:00:00", collar_id=1, collar_key="K")
+    mock_get_obs.side_effect = VectronicForbiddenException(Exception("403"), "Unauthorized access")
+    result = await action_fetch_collar_observations(integration, config)
+    assert result == {"observations_extracted": 0}
+    mock_log_action_activity.assert_awaited_once()
+    assert mock_log_action_activity.call_args[1]["action_id"] == "fetch_collar_observations"
+    assert mock_log_action_activity.call_args[1]["level"] == LogLevel.WARNING
+
+@pytest.mark.asyncio
+async def test_action_fetch_collar_observations_not_found_logs_warning(mocker):
+    mock_get_obs = mocker.patch("app.actions.handlers.client.get_observations", new_callable=AsyncMock)
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new_callable=AsyncMock)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    integration = MagicMock(id=1, base_url=None)
+    config = PullCollarObservationsConfig(start="2024-01-01T00:00:00", collar_id=1, collar_key="K")
+    mock_get_obs.side_effect = VectronicNotFoundException(Exception("404"), "Not found")
+    result = await action_fetch_collar_observations(integration, config)
+    assert result == {"observations_extracted": 0}
+    mock_log_action_activity.assert_awaited_once()
+    assert mock_log_action_activity.call_args[1]["action_id"] == "fetch_collar_observations"
+    assert mock_log_action_activity.call_args[1]["level"] == LogLevel.WARNING
+
+@pytest.mark.asyncio
+async def test_action_fetch_collar_observations_http_status_error_logs_warning(mocker):
+    mock_get_obs = mocker.patch("app.actions.handlers.client.get_observations", new_callable=AsyncMock)
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new_callable=AsyncMock)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    integration = MagicMock(id=1, base_url=None)
+    config = PullCollarObservationsConfig(start="2024-01-01T00:00:00", collar_id=1, collar_key="K")
+    request = httpx.Request("GET", "https://api.vectronic-wildlife.com/v2/collar/1/gps")
+    response = httpx.Response(status_code=500, request=request, text="Internal Server Error")
+    mock_get_obs.side_effect = httpx.HTTPStatusError("Server error", request=request, response=response)
+    result = await action_fetch_collar_observations(integration, config)
+    assert result == {"observations_extracted": 0}
+    mock_log_action_activity.assert_awaited_once()
+    assert mock_log_action_activity.call_args[1]["action_id"] == "fetch_collar_observations"
+    assert mock_log_action_activity.call_args[1]["level"] == LogLevel.WARNING
 
 def test_transform_ok():
     obj = {


### PR DESCRIPTION
## Problem

In production we see a lot of ActivityLog **ERROR** entries that should be **WARNING**. When a collar-fetch request to the Vectronic API returns a 4xx/5xx, `action_fetch_collar_observations` logs it as an ERROR — but these are upstream/transient conditions (bad collar key/ID, collar not found, server-side issues), not integration faults.

## Changes

In `action_fetch_collar_observations`, collar-fetch HTTP error responses now log as `WARNING`:

- **403** (`VectronicForbiddenException`) → `WARNING` (was ERROR)
- **404** (`VectronicNotFoundException`) → `WARNING` (was ERROR)
- **Other 4xx / all 5xx** → new `except httpx.HTTPStatusError` block → `WARNING` (previously fell into the catch-all and logged ERROR)

The catch-all `except Exception` **stays at `ERROR`**, so genuine non-HTTP failures (timeouts, JSON/pydantic parse errors, code bugs) are still surfaced as errors. `logger.exception(...)` was also dropped to `logger.warning(...)` for the HTTP cases so the local log severity matches the activity-log severity.

### Drive-by fix
These activity-log calls reported `action_id="pull_observations"`, but the action is `fetch_collar_observations` — now corrected. The `state_manager.get_state`/`set_state` calls keep `"pull_observations"` intentionally, since that is the shared state-key namespace for the two-stage pull pattern.

## Tests

Added three tests for the WARNING behavior (403 / 404 / 500) and `action_id` assertions across the exception tests. The pre-existing generic-exception test still asserts ERROR, confirming the split. Full suite: **73 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)