### PR TITLE
Sync upstream template: skip unconfigured scheduled pull actions

### DIFF
--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -2,7 +2,7 @@ import importlib
 import inspect
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from app.services.utils import UISchemaModelMixin
 
 
@@ -15,7 +15,22 @@ class InternalActionConfiguration(BaseModel):
 
 
 class PullActionConfiguration(ActionConfiguration):
-    pass
+    # Pull actions are scheduled at the integration-type level, so the portal
+    # fires them for every integration of this type. This toggle lets an
+    # operator pause scheduled execution for a given integration without
+    # deleting its configuration — useful when the integration is used only as
+    # a destination and the pull is not intended to run. The action_runner also
+    # treats a missing or invalid pull config as a clean no-op rather than an
+    # error, so destination-only integrations stay quiet by default.
+    run_on_schedule: bool = Field(
+        True,
+        title="Run On Schedule",
+        description=(
+            "When enabled, this action runs automatically on its configured schedule. "
+            "Turn it off to pause scheduled execution for this integration without deleting "
+            "the configuration."
+        ),
+    )
 
 
 class ExecutableActionMixin:

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 
@@ -6,4 +8,8 @@ class ActionRequest(BaseModel):
     action_id: str
     run_in_background: bool = False
     config_overrides: dict = None
+    # How the run was initiated. The /execute endpoint is an explicit, direct
+    # invocation, so it defaults to "manual" when unset (see the router) —
+    # keeping the strict 404/422 behavior for misconfigured pull actions.
+    triggered_by: Optional[str] = None
 

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -866,6 +866,9 @@ def mock_state_manager(mocker):
         {"last_execution": "2023-11-17T11:20:00+0200"}
     )
     mock_state_manager.set_state.return_value = async_return(None)
+    # Default: throttle window is open (first-in-window), so throttled events
+    # publish. Tests that exercise the suppressed path override this.
+    mock_state_manager.set_if_absent.return_value = async_return(True)
     return mock_state_manager
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -77,18 +77,24 @@ async def execute(
     payload = base64.b64decode(json_data["message"]["data"]).decode("utf-8").strip()
     json_payload = json.loads(payload)
     logger.debug(f"JSON Payload: {json_payload}")
+    # `triggered_by` lets the portal mark how the run was initiated (e.g. a
+    # scheduled tick vs an operator's "Run now"). Absent the marker we default
+    # to automated, so scheduled pulls on destination-only integrations skip
+    # quietly instead of erroring.
     if settings.PROCESS_PUBSUB_MESSAGES_IN_BACKGROUND:
         background_tasks.add_task(
             execute_action,
             integration_id=json_payload.get("integration_id"),
             action_id=json_payload.get("action_id"),
             config_overrides=json_payload.get("config_overrides"),
+            triggered_by=json_payload.get("triggered_by"),
         )
     else:
         await execute_action(
             integration_id=json_payload.get("integration_id"),
             action_id=json_payload.get("action_id"),
             config_overrides=json_payload.get("config_overrides"),
+            triggered_by=json_payload.get("triggered_by"),
         )
     return {}
 

--- a/app/routers/actions.py
+++ b/app/routers/actions.py
@@ -3,7 +3,7 @@ from typing import List
 import app.settings
 from fastapi import APIRouter, BackgroundTasks
 from app.actions import get_actions
-from app.services.action_runner import execute_action
+from app.services.action_runner import execute_action, ActionTrigger
 from app.api_schemas import ActionRequest
 
 logger = logging.getLogger(__name__)
@@ -27,17 +27,22 @@ async def execute(
     request: ActionRequest,
     background_tasks: BackgroundTasks
 ):
+    # Direct /execute calls are explicit invocations → manual by default, so a
+    # misconfigured pull action surfaces a 404/422 here rather than skipping.
+    triggered_by = request.triggered_by or ActionTrigger.MANUAL.value
     if request.run_in_background:
         background_tasks.add_task(
             execute_action,
             integration_id=request.integration_id,
             action_id=request.action_id,
-            config_overrides=request.config_overrides
+            config_overrides=request.config_overrides,
+            triggered_by=triggered_by,
         )
         return {"message": "Action execution started in background"}
     else:
         return await execute_action(
             integration_id=request.integration_id,
             action_id=request.action_id,
-            config_overrides=request.config_overrides
+            config_overrides=request.config_overrides,
+            triggered_by=triggered_by,
         )

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 import traceback
+from enum import Enum
 from typing import Optional
 
 import httpx
@@ -14,15 +15,44 @@ from app import settings
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from gundi_core.events import IntegrationActionFailed, ActionExecutionFailed
+from gundi_core.events import IntegrationActionFailed, ActionExecutionFailed, LogLevel
 
+from app.actions.core import PullActionConfiguration
 from .config_manager import IntegrationConfigurationManager
+from .state import IntegrationStateManager
 from .utils import find_config_for_action
-from .activity_logger import publish_event
+from .activity_logger import publish_event, log_action_activity
 
 _portal = GundiClient()
 config_manager = IntegrationConfigurationManager()
+state_manager = IntegrationStateManager()
 logger = logging.getLogger(__name__)
+
+# How often (seconds) to publish a portal activity-log WARNING for a pull
+# action that keeps skipping on an invalid config. Pull actions are scheduled
+# type-wide and fire on every tick; without throttling a persistently
+# misconfigured source would emit a WARNING every run. The skip itself is
+# always recorded in the local application log — this only rate-limits the
+# portal-facing activity-feed entry.
+SKIP_WARNING_THROTTLE_SECONDS = 3600
+
+
+class ActionTrigger(str, Enum):
+    """Where an action invocation originated.
+
+    AUTO covers the portal's scheduler — and, by default, anything that
+    doesn't say otherwise. For automated pull-action runs, a missing/invalid
+    config (or a paused `run_on_schedule`) is a clean no-op, because pull
+    actions are scheduled type-wide and fire even for destination-only
+    integrations that never get a pull config.
+
+    MANUAL is an explicit, operator-initiated run. Those keep the strict
+    404/422 behavior so a real misconfiguration surfaces immediately, and they
+    ignore the `run_on_schedule` pause toggle (a manual run is not "on
+    schedule").
+    """
+    AUTO = "auto"
+    MANUAL = "manual"
 
 
 async def _handle_error(
@@ -73,9 +103,64 @@ async def _handle_error(
     )
 
 
+def _skip_quietly(integration_id, action_id, *, reason, message, log_level=logging.INFO):
+    """Record an expected pull-action skip in the local log only.
+
+    Destination-only integrations get pull actions scheduled type-wide but
+    have no usable config, and operators may deliberately pause a pull. These
+    are expected, steady-state no-ops, so we keep them out of the portal
+    activity feed entirely (no `IntegrationActionFailed`, no custom log) to
+    avoid per-tick noise — the local application log is enough for debugging.
+    """
+    logger.log(log_level, f"{message} (integration '{integration_id}')")
+    return {"skipped": True, "reason": reason}
+
+
+async def _skip_invalid_config(integration_id, action_id, *, error):
+    """Record a skip caused by a missing/invalid pull config.
+
+    Unlike the expected skips, an invalid (rather than absent) config usually
+    means a real source with a misconfiguration, so it IS worth surfacing in
+    the portal activity feed — but only at WARNING and throttled to at most
+    once per `SKIP_WARNING_THROTTLE_SECONDS`, so a persistently broken source
+    doesn't emit a WARNING on every scheduled tick. The skip is always written
+    to the local application log regardless.
+    """
+    logger.warning(
+        f"Skipping '{action_id}': configuration is missing or invalid "
+        f"(integration '{integration_id}'): {error}"
+    )
+    try:
+        first_in_window = await state_manager.set_if_absent(
+            integration_id=integration_id,
+            action_id=action_id,
+            source_id="skip-invalid-config-warning",
+            ttl_seconds=SKIP_WARNING_THROTTLE_SECONDS,
+        )
+    except Exception as throttle_error:
+        # The throttle is best-effort noise control. If the state store is
+        # unavailable, don't let it crash the skip — that would turn a benign
+        # no-op into an unhandled error (500 / PubSub redelivery). Fail open:
+        # surface the misconfiguration this time rather than hiding it.
+        logger.warning(
+            f"Skip-warning throttle unavailable for '{action_id}' "
+            f"(integration '{integration_id}'): {throttle_error}. Publishing the warning."
+        )
+        first_in_window = True
+    if first_in_window:
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id=action_id,
+            title=f"Skipping '{action_id}': configuration is missing or invalid.",
+            level=LogLevel.WARNING,
+            data={"validation_error": str(error)},
+        )
+    return {"skipped": True, "reason": "invalid_configuration"}
+
+
 async def execute_action(
         integration_id: str, action_id: Optional[str] = None, config_overrides: dict = None,
-        data: dict = None, metadata: dict = None
+        data: dict = None, metadata: dict = None, triggered_by: Optional[str] = None
 ):
     try:  # Get the integration details to pass it to the action handler
         integration = await config_manager.get_integration_details(integration_id)
@@ -110,9 +195,28 @@ async def execute_action(
 
     logger.info(f"Executing action '{action_id}' for integration '{integration_id}'...")
 
+    # Pull actions are scheduled type-wide, so the portal fires them for every
+    # integration of this type — including destination-only ones that never get
+    # a pull config. For an *automated* run, "no usable config" (or a paused
+    # toggle) means "nothing to pull" — a clean no-op rather than a failure. A
+    # *manual* run keeps the strict 404/422 behavior so misconfigurations
+    # surface immediately, and ignores the pause toggle.
+    is_pull_action = isinstance(config_model, type) and issubclass(config_model, PullActionConfiguration)
+    # Normalize the marker so casing/whitespace from the caller (e.g. the
+    # portal) doesn't silently fall through to the automated default.
+    is_manual = (triggered_by or "").strip().lower() == ActionTrigger.MANUAL.value
+    skippable_pull = is_pull_action and not is_manual
+
     # Get the configuration needed to execute the action
     action_config = await config_manager.get_action_configuration(integration_id, action_id)
     if not action_config and not config_overrides:
+        if skippable_pull:
+            return _skip_quietly(
+                integration_id, action_id,
+                reason="no_configuration",
+                message=f"Skipping '{action_id}': integration is not configured for this action.",
+                log_level=logging.DEBUG,
+            )
         message = f"Configuration for action '{action_id}' for integration {str(integration.id)} is missing."
         logger.error(message)
         return await _handle_error(
@@ -127,7 +231,22 @@ async def execute_action(
             config_data.update(config_overrides)
         parsed_config = config_model.parse_obj(config_data)
     except pydantic.ValidationError as e:
+        # An automated pull whose config doesn't validate has nothing it can
+        # safely pull. Skip rather than raise — surfaced at WARNING in the
+        # activity feed (throttled) so a genuinely misconfigured source stays
+        # noticeable without spamming a warning on every tick.
+        if skippable_pull:
+            return await _skip_invalid_config(integration_id, action_id, error=e)
         return await _handle_error(e, integration_id, action_id, config_data, status.HTTP_422_UNPROCESSABLE_ENTITY)
+
+    # Respect the operator's explicit pause toggle — only for scheduled runs.
+    if skippable_pull and not getattr(parsed_config, "run_on_schedule", True):
+        return _skip_quietly(
+            integration_id, action_id,
+            reason="run_on_schedule_disabled",
+            message=f"Skipping '{action_id}': 'run_on_schedule' is turned off for this integration.",
+            log_level=logging.INFO,
+        )
 
     parsed_data = None
     if data and DataModel:

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -28,6 +28,26 @@ class IntegrationStateManager:
                     json.dumps(state, default=str)
                 )
 
+    async def set_if_absent(
+        self, integration_id: str, action_id: str, *, ttl_seconds: int, source_id: str = "no-source"
+    ) -> bool:
+        """Atomically set a key only if it does not already exist, with a TTL.
+
+        Returns True if the key was set by this call (i.e. the caller is the
+        first within the TTL window), or False if it already existed. Useful
+        for rate-limiting/throttling repeated events: the first caller in each
+        window gets True, the rest get False until the key expires.
+        """
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                was_set = await self.db_client.set(
+                    f"integration_state.{integration_id}.{action_id}.{source_id}",
+                    "1",
+                    ex=ttl_seconds,
+                    nx=True,
+                )
+        return bool(was_set)
+
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -5,15 +5,31 @@ import pytest
 from fastapi.testclient import TestClient
 from fastapi import status
 from gundi_core.commands import RunIntegrationAction
-from gundi_core.events import IntegrationActionFailed
+from gundi_core.events import IntegrationActionFailed, IntegrationActionCustomLog, LogLevel
 from gundi_core.events.transformers import ObservationTransformedER
 
 from app import settings
-from app.conftest import MockSubActionConfiguration, MockPushActionConfiguration
+from app.conftest import MockSubActionConfiguration, MockPushActionConfiguration, async_return
 from app.main import app
 from app.services.action_scheduler import trigger_action
 
 api_client = TestClient(app)
+
+
+def _published_events_of_type(mock_publish_event, event_type):
+    """Collect events of a given type passed to a mocked publish_event.
+
+    publish_event is called as publish_event(event=..., topic_name=...) in some
+    paths and publish_event(event, topic) positionally in others, so check both.
+    """
+    events = []
+    for call in mock_publish_event.mock_calls:
+        event = call.kwargs.get("event")
+        if event is None and call.args:
+            event = call.args[0]
+        if isinstance(event, event_type):
+            events.append(event)
+    return events
 
 
 @pytest.mark.asyncio
@@ -177,10 +193,12 @@ async def test_execute_action_from_pubsub_with_config_overrides(
 
 
 @pytest.mark.asyncio
-async def test_execute_action_from_api_with_invalid_config(
+async def test_manual_pull_action_with_invalid_config_still_errors(
         mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
         mock_publish_event, mock_action_handlers,
 ):
+    # A direct /execute call is a manual run → strict: invalid config 422s so
+    # the operator sees the misconfiguration immediately.
     mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
@@ -197,6 +215,251 @@ async def test_execute_action_from_api_with_invalid_config(
     )
 
     assert response.status_code == 422
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_triggered_by_marker_is_case_insensitive(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers, pubsub_message_request_headers,
+):
+    # A mixed-case "MANUAL" marker must be honored as a manual run (strict), not
+    # silently fall through to the automated default. With an invalid config that
+    # means it errors (IntegrationActionFailed) rather than skipping quietly.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}  # should be an integer
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+    encoded = base64.b64encode(json.dumps({
+        "integration_id": str(integration_v2.id),
+        "action_id": "pull_observations",
+        "triggered_by": "MANUAL",  # not the canonical lowercase "manual"
+    }).encode("utf-8")).decode("utf-8")
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json={"message": {"data": encoded}},
+    )
+
+    assert response.status_code == 200  # POST / always returns {}; behavior is observed via events
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    # Treated as manual → strict → error published, NOT a quiet skip.
+    assert _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_pull_action_with_invalid_config_is_skipped(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_action_handlers, mock_state_manager, pubsub_message_request_headers,
+        run_pull_action_pubsub_payload,
+):
+    # A scheduled (PubSub, no triggered_by → automated) pull whose stored config
+    # is invalid skips cleanly: no handler call, NO IntegrationActionFailed, and
+    # — when the throttle window is open — one WARNING activity log with detail.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_state_manager.set_if_absent.return_value = async_return(True)  # window open
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}  # should be an integer
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json=run_pull_action_pubsub_payload,
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    skip_logs = _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+    assert len(skip_logs) == 1
+    assert skip_logs[0].payload.level == LogLevel.WARNING
+    assert "validation_error" in (skip_logs[0].payload.data or {})
+
+
+@pytest.mark.asyncio
+async def test_scheduled_pull_action_invalid_config_warning_is_throttled(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_action_handlers, mock_state_manager, pubsub_message_request_headers,
+        run_pull_action_pubsub_payload,
+):
+    # When the throttle window is closed (set_if_absent → False), the skip is
+    # still logged locally but NO portal WARNING is published — so a
+    # persistently misconfigured source doesn't emit a warning every tick.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_state_manager.set_if_absent.return_value = async_return(False)  # window closed
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json=run_pull_action_pubsub_payload,
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_pull_action_invalid_config_skip_survives_throttle_failure(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_action_handlers, mock_state_manager, pubsub_message_request_headers,
+        run_pull_action_pubsub_payload,
+):
+    # If the throttle store (Redis) is unavailable, the skip must not crash the
+    # request (which would 500 / trigger PubSub redelivery). It degrades open:
+    # the WARNING is still published this time, and nothing is raised.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_state_manager.set_if_absent.side_effect = Exception("redis unavailable")
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"lookback_days": "two"}
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json=run_pull_action_pubsub_payload,
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    # Fail-open: the misconfiguration WARNING is still surfaced.
+    skip_logs = _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+    assert len(skip_logs) == 1
+    assert skip_logs[0].payload.level == LogLevel.WARNING
+
+
+@pytest.mark.asyncio
+async def test_scheduled_pull_action_with_missing_config_is_skipped(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_action_handlers, pubsub_message_request_headers, run_pull_action_pubsub_payload,
+):
+    # Destination-only integrations have pull actions scheduled type-wide but no
+    # pull config at all — an expected, quiet no-op: local log only, NO portal
+    # activity-feed event at all.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mock_config_manager.get_action_configuration.return_value = async_return(None)
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json=run_pull_action_pubsub_payload,
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_pull_action_skipped_when_run_on_schedule_disabled(
+        mocker, mock_gundi_client_v2, mock_config_manager, mock_publish_event,
+        mock_action_handlers, pubsub_message_request_headers, run_pull_action_pubsub_payload,
+):
+    # A valid config with run_on_schedule off pauses scheduled execution — also
+    # a quiet, local-log-only skip with no portal activity-feed event.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    paused_config = mocker.MagicMock()
+    paused_config.data = {"lookback_days": 10, "run_on_schedule": False}
+    mock_config_manager.get_action_configuration.return_value = async_return(paused_config)
+
+    response = api_client.post(
+        "/", headers=pubsub_message_request_headers, json=run_pull_action_pubsub_payload,
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert not mock_action_handler.called
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+
+
+@pytest.mark.asyncio
+async def test_manual_pull_action_runs_even_when_run_on_schedule_disabled(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers,
+):
+    # The pause toggle only gates scheduled runs — a manual /execute still runs.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    paused_config = mocker.MagicMock()
+    paused_config.data = {"lookback_days": 10, "run_on_schedule": False}
+    mock_config_manager.get_action_configuration.return_value = async_return(paused_config)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={
+            "integration_id": str(integration_v2.id),
+            "action_id": "pull_observations",
+        }
+    )
+
+    assert response.status_code == 200
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations"]
+    assert mock_action_handler.called
+
+
+@pytest.mark.asyncio
+async def test_non_pull_action_still_errors_on_invalid_config(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers,
+):
+    # The skip-on-invalid behavior is scoped to pull actions only — a non-pull
+    # (here InternalActionConfiguration) action with a bad config still 422s.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    bad_config = mocker.MagicMock()
+    bad_config.data = {"start_datetime": "not-a-datetime", "end_datetime": "also-bad"}
+    mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={
+            "integration_id": str(integration_v2.id),
+            "action_id": "pull_observations_by_date",
+        }
+    )
+
+    assert response.status_code == 422
+    mock_action_handler, _, _ = mock_action_handlers["pull_observations_by_date"]
+    assert not mock_action_handler.called
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -37,6 +37,16 @@ async def test_register_integration_with_slug_setting(
                         "title": "MockPullActionConfiguration",
                         "type": "object",
                         "properties": {
+                            "run_on_schedule": {
+                                "title": "Run On Schedule",
+                                "description": (
+                                    "When enabled, this action runs automatically on its configured schedule. "
+                                    "Turn it off to pause scheduled execution for this integration without deleting "
+                                    "the configuration."
+                                ),
+                                "default": True,
+                                "type": "boolean",
+                            },
                             "lookback_days": {
                                 "title": "Data lookback days",
                                 "description": "Number of days to look back for data.",
@@ -151,6 +161,16 @@ async def test_register_integration_with_slug_arg(
                         "title": "MockPullActionConfiguration",
                         "type": "object",
                         "properties": {
+                            "run_on_schedule": {
+                                "title": "Run On Schedule",
+                                "description": (
+                                    "When enabled, this action runs automatically on its configured schedule. "
+                                    "Turn it off to pause scheduled execution for this integration without deleting "
+                                    "the configuration."
+                                ),
+                                "default": True,
+                                "type": "boolean",
+                            },
                             "lookback_days": {
                                 "title": "Data lookback days",
                                 "description": "Number of days to look back for data.",
@@ -266,6 +286,16 @@ async def test_register_integration_with_service_url_arg(
                         "title": "MockPullActionConfiguration",
                         "type": "object",
                         "properties": {
+                            "run_on_schedule": {
+                                "title": "Run On Schedule",
+                                "description": (
+                                    "When enabled, this action runs automatically on its configured schedule. "
+                                    "Turn it off to pause scheduled execution for this integration without deleting "
+                                    "the configuration."
+                                ),
+                                "default": True,
+                                "type": "boolean",
+                            },
                             "lookback_days": {
                                 "title": "Data lookback days",
                                 "description": "Number of days to look back for data.",
@@ -384,6 +414,16 @@ async def test_register_integration_with_service_url_setting(
                         "title": "MockPullActionConfiguration",
                         "type": "object",
                         "properties": {
+                            "run_on_schedule": {
+                                "title": "Run On Schedule",
+                                "description": (
+                                    "When enabled, this action runs automatically on its configured schedule. "
+                                    "Turn it off to pause scheduled execution for this integration without deleting "
+                                    "the configuration."
+                                ),
+                                "default": True,
+                                "type": "boolean",
+                            },
                             "lookback_days": {
                                 "title": "Data lookback days",
                                 "description": "Number of days to look back for data.",

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -2,6 +2,7 @@ import datetime
 import json
 
 import pytest
+from app.conftest import async_return
 from app.services.state import IntegrationStateManager
 
 
@@ -78,6 +79,40 @@ async def test_delete_integration_state(mocker, mock_redis, integration_v2):
     mock_redis.Redis.return_value.delete.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.no-source"
     )
+
+
+@pytest.mark.asyncio
+async def test_set_if_absent(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    state_manager = IntegrationStateManager()
+    integration_id = str(integration_v2.id)
+
+    # Redis SET ... NX EX returns a truthy value when the key was absent (set),
+    # and None when it already existed (not set / throttled).
+    mock_redis.Redis.return_value.set.return_value = async_return("OK")
+    was_set = await state_manager.set_if_absent(
+        integration_id=integration_id,
+        action_id="pull_observations",
+        source_id="skip-invalid-config-warning",
+        ttl_seconds=3600,
+    )
+    assert was_set is True
+    mock_redis.Redis.return_value.set.assert_called_once_with(
+        f"integration_state.{integration_id}.pull_observations.skip-invalid-config-warning",
+        "1",
+        ex=3600,
+        nx=True,
+    )
+
+    # Key already present within the window → Redis returns None → False.
+    mock_redis.Redis.return_value.set.return_value = async_return(None)
+    was_set = await state_manager.set_if_absent(
+        integration_id=integration_id,
+        action_id="pull_observations",
+        source_id="skip-invalid-config-warning",
+        ttl_seconds=3600,
+    )
+    assert was_set is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Brings the action runner up to date with the [`gundi-integration-action-runner`](https://github.com/padas/gundi-integration-action-runner) template's **"skip unconfigured scheduled pull actions"** feature (upstream PRs through #76).

## Why

Pull actions are scheduled at the integration-*type* level, so the portal fires them for every integration of this type — including destination-only ones that never get a pull config. Today a missing/invalid config produces a `404`/`422` error and an activity-feed entry on **every** scheduled tick, which is the bulk of the production noise.

## Behavior change

`execute_action` now takes a `triggered_by` marker (`AUTO` vs `MANUAL`, normalized case/whitespace-insensitively):

- **Scheduled / PubSub runs → AUTO (default).** A missing config or a paused `run_on_schedule` toggle becomes a quiet, local-log-only no-op (no activity-feed event). An *invalid* config is surfaced at **WARNING**, throttled to once per hour via the new `IntegrationStateManager.set_if_absent` (Redis `NX` + TTL). The throttle **fails open** if Redis is unavailable, so a benign skip never crashes into a 500 / PubSub redelivery loop.
- **`/execute` API runs → MANUAL (default).** Strict `404`/`422` behavior is preserved and the pause toggle is ignored, so real misconfigurations still surface immediately.
- `PullActionConfiguration` gains a **`run_on_schedule`** toggle so an operator can pause a scheduled pull without deleting its config.

## Files

Synced from upstream (pure template): `action_runner.py`, `state.py`, `routers/actions.py`, `api_schemas.py`, `actions/core.py`, and the `test_action_runner.py` / `test_state_manager.py` specs. `conftest.py` gained the `set_if_absent` default on `mock_state_manager`; `test_self_registration.py` gained the `run_on_schedule` schema property.

## Scope / what was deliberately left out

- **Integration-specific files untouched**: `actions/handlers.py`, `actions/configurations.py`, `actions/client.py`, webhook handler, `config_manager.py`, `gundi.py`.
- **`main.py` edited surgically** — only the `triggered_by` plumbing was added; the upstream `close_diagnostic_client` hook was *not* pulled in, since it belongs to the separate (out-of-scope) webhook-diagnostics feature and would break the import here.

## Tests

Brought the upstream specs in first, confirmed they failed against the old code, then applied the implementation. Full suite: **79 passed**.

> Note: independent of the open WARNING-logging PR #8 (separate branch off `main`); whichever merges first, the other rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)